### PR TITLE
[ROGUE-2520] Fix crash on MXRoomState handleStateEvents

### DIFF
--- a/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
+++ b/MatrixSDK/Data/Store/MXFileStore/MXFileStore.m
@@ -63,6 +63,7 @@ static NSUInteger preloadOptions;
     NSMutableArray *roomsToCommitForOutgoingMessages;
 
     NSMutableDictionary *roomsToCommitForState;
+    NSLock *roomsToCommitForStateLock;
 
     NSMutableDictionary<NSString*, MXRoomAccountData*> *roomsToCommitForAccountData;
     
@@ -147,6 +148,7 @@ static NSUInteger preloadOptions;
         roomsToCommitForMessages = [NSMutableArray array];
         roomsToCommitForOutgoingMessages = [NSMutableArray array];
         roomsToCommitForState = [NSMutableDictionary dictionary];
+        roomsToCommitForStateLock = [NSLock new];
         roomsToCommitForAccountData = [NSMutableDictionary dictionary];
         roomsToCommitForReceipts = [NSMutableArray array];
         roomsToCommitForDeletion = [NSMutableArray array];
@@ -540,7 +542,9 @@ static NSUInteger preloadOptions;
 
 - (void)storeStateForRoom:(NSString*)roomId stateEvents:(NSArray*)stateEvents
 {
+    [roomsToCommitForStateLock lock];
     roomsToCommitForState[roomId] = stateEvents;
+    [roomsToCommitForStateLock unlock];
 }
 
 - (void)stateOfRoom:(NSString *)roomId success:(void (^)(NSArray<MXEvent *> * _Nonnull))success failure:(void (^)(NSError * _Nonnull))failure
@@ -1498,11 +1502,13 @@ static NSUInteger preloadOptions;
 
 - (void)saveRoomsState
 {
+    [roomsToCommitForStateLock lock];
     if (roomsToCommitForState.count)
     {
         // Take a snapshot of room ids to store to process them on the other thread
         NSDictionary *roomsToCommit = [NSDictionary dictionaryWithDictionary:roomsToCommitForState];
         [roomsToCommitForState removeAllObjects];
+        [roomsToCommitForStateLock unlock];
 #if DEBUG
         MXLogDebug(@"[MXFileStore commit] queuing saveRoomsState for %tu rooms", roomsToCommit.count);
 #endif
@@ -1534,6 +1540,8 @@ static NSUInteger preloadOptions;
             MXLogDebug(@"[MXFileStore commit] lasted %.0fms for %tu rooms state", [[NSDate date] timeIntervalSinceDate:startDate] * 1000, roomsToCommit.count);
 #endif
         });
+    } else {
+        [roomsToCommitForStateLock unlock];
     }
 }
 


### PR DESCRIPTION
Task on Runway [ROGUE-2520](https://nitro.powerhrg.com/runway/backlog_items/ROGUE-2520).

### Notes

- Added locks to reduce the chances of crash by thread concurrency, applied the same approach as [ROGUE-2502](https://github.com/powerhome/matrix-ios-sdk/pull/16) and [ROGUE-2484](https://github.com/powerhome/matrix-ios-sdk/pull/15)
