### PR TITLE
[ROGUE-2522] Fix null safety to removeAllSpiedRooms

### DIFF
--- a/MatrixSDK/Data/MXSessionEventListener.m
+++ b/MatrixSDK/Data/MXSessionEventListener.m
@@ -66,11 +66,14 @@
 {
     // Here sender is the MXSession instance. Cast it
     MXSession *mxSession = (MXSession *)self.sender;
-    
+
     for (NSString *roomId in roomEventListeners)
     {
         MXRoom *room = [mxSession roomWithRoomId:roomId];
-        [room removeListener:self->roomEventListeners[room.roomId]];
+        if (room)
+        {
+            [room removeListener:self->roomEventListeners[roomId]];
+        }
     }
     [roomEventListeners removeAllObjects];
 }


### PR DESCRIPTION
Prevent EXC_BAD_ACCESS crash during session close by:
- Adding null check before calling removeListener on room
- Using loop variable roomId instead of room.roomId for dictionary lookup (room.roomId is nil when room is nil, silently skipping listener cleanup)

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request contains a changelog file in ./changelog.d. See https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
